### PR TITLE
Explicitly use ordinal comparison everywhere

### DIFF
--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -391,7 +391,7 @@ namespace Lunr
         private TokenSet CreateTokenSet()
             => TokenSet = TokenSet.FromArray(InvertedIndex
                 .Keys
-                .OrderBy(k => k));
+                .OrderBy(k => k, StringComparer.Ordinal));
 
         private void InitializeFields(params Field[] fields)
         {

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Lunr</RootNamespace>
-    <Version>2.3.8</Version>
+    <Version>2.3.8.1</Version>
     <Authors>Bertrand Le Roy</Authors>
     <Company>Decent Consulting</Company>
     <Description>A .NET Core port of Oliver Nightingale's lunr.js library, a lightweight full-text indexing library that is "a bit like Solr, but much smaller and not as bright." Icon adapted from https://commons.wikimedia.org/wiki/File:Internal_Structure_of_the_Moon.JPG by Iqbal Mahmud under Creative Commons Attribution Share Alike 4.0 International</Description>

--- a/LunrCore/Serialization/InvertedIndexJsonConverter.cs
+++ b/LunrCore/Serialization/InvertedIndexJsonConverter.cs
@@ -29,7 +29,7 @@ namespace Lunr.Serialization
         public override void Write(Utf8JsonWriter writer, InvertedIndex value, JsonSerializerOptions options)
         {
             writer.WriteStartArray();
-            foreach((string term, InvertedIndexEntry entry) in value.OrderBy(kvp => kvp.Key))
+            foreach((string term, InvertedIndexEntry entry) in value.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
             {
                 writer.WriteStartArray();
                 writer.WriteValue(term, options);

--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -382,7 +382,7 @@ namespace Lunr
 
             var str = new StringBuilder(IsFinal ? "1" : "0");
 
-            foreach ((char label, TokenSet node) in Edges.OrderBy(k => k.Key))
+            foreach ((char label, TokenSet node) in Edges.OrderBy(k => k.Key.ToString(), StringComparer.Ordinal))
             {
                 str.Append(label);
                 str.Append(node.Id);
@@ -412,7 +412,7 @@ namespace Lunr
             {
                 int commonPrefix = 0;
 
-                if (word.CompareTo(_previousWord) == -1)
+                if (StringComparer.Ordinal.Compare(word, _previousWord) < 0)
                     throw new InvalidOperationException("Out of order word insertion.");
 
                 for (int i = 0; i < word.Length && i < _previousWord.Length; i ++)

--- a/LunrCoreTests/SerializationTest.cs
+++ b/LunrCoreTests/SerializationTest.cs
@@ -63,7 +63,6 @@ namespace LunrCoreTests
 
             // We want strict compatibility of index serialization with lunr.js
             Assert.Equal(_lunrJsSerializedIndex, serializedIndex);
-
         }
 
         [Fact]
@@ -72,6 +71,41 @@ namespace LunrCoreTests
             var deserializedIndex = Index.LoadFromJson(_lunrJsSerializedIndex);
 
             Assert.Equal(_lunrJsSerializedIndex, deserializedIndex.ToJson());
+        }
+
+        [Fact]
+        public async Task CanSerializeIndexInOrderWithUnderscoresAndDigits()
+        {
+            Index idx = await Index.Build(async builder =>
+            {
+                builder.ReferenceField = "id";
+
+                builder.AddField("title");
+
+                await builder.Add(new Document
+                {
+                    { "id", "underscore" },
+                    { "title", "_" }
+                });
+
+                await builder.Add(new Document
+                {
+                    { "id", "zero" },
+                    { "title", "0" }
+                });
+
+                await builder.Add(new Document
+                {
+                    { "id", "all the things" },
+                    { "title", "0 _" }
+                });
+            });
+
+            string serializedIndex = idx.ToJson();
+
+            // We want strict compatibility of index serialization with lunr.js
+            Assert.Equal("{\"version\":\"2.3.8\",\"fields\":[\"title\"],\"fieldVectors\":[[\"title/underscore\",[0,0.524]],[\"title/zero\",[1,0.524]],[\"title/all the things\",[0,0.39,1,0.39]]],\"invertedIndex\":[[\"0\",{\"_index\":1,\"title\":{\"zero\":{},\"all the things\":{}}}],[\"_\",{\"_index\":0,\"title\":{\"underscore\":{},\"all the things\":{}}}]],\"pipeline\":[\"stemmer\"]}",
+                serializedIndex);
         }
     }
 }


### PR DESCRIPTION
In particular when ordering the inverted index, which was causing incompatibilities with lunr.js when using with terms that are numeric or underscore.
Fixes #2