### PR TITLE
Reduce virtual calls

### DIFF
--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -77,7 +77,7 @@ namespace Lunr
         /// <summary>
         /// The list of fields for this builder.
         /// </summary>
-        public IEnumerable<Field> Fields => _fields.Values;
+        public ICollection<Field> Fields => _fields.Values;
 
         /// <summary>
         /// The set of all tokens in the index.

--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -18,9 +18,9 @@ namespace Lunr
     /// </summary>
     public class Builder
     {
-        private readonly IDictionary<string, Field> _fields = new Dictionary<string, Field>();
-        private readonly IDictionary<string, Document> _documents = new Dictionary<string, Document>();
-        private readonly IDictionary<FieldReference, int> _fieldLengths = new Dictionary<FieldReference, int>();
+        private readonly Dictionary<string, Field> _fields = new ();
+        private readonly Dictionary<string, Document> _documents = new ();
+        private readonly Dictionary<FieldReference, int> _fieldLengths = new ();
         private readonly ITokenizer _tokenizer;
         private int _termIndex = 0;
         private double _b = 0.75;
@@ -59,8 +59,7 @@ namespace Lunr
             Separator = Tokenizer.DefaultSeparator;
         }
 
-        public FieldTermFrequencies FieldTermFrequencies { get; }
-            = new FieldTermFrequencies();
+        public FieldTermFrequencies FieldTermFrequencies { get; } = new ();
 
         /// <summary>
         /// The document field used as the document reference. Every document must have this field.
@@ -83,28 +82,27 @@ namespace Lunr
         /// <summary>
         /// The set of all tokens in the index.
         /// </summary>
-        public TokenSet TokenSet { get; set; } = new TokenSet();
+        public TokenSet TokenSet { get; set; } = new ();
 
         /// <summary>
         /// Average field lenghts.
         /// </summary>
-        public IDictionary<string, double> AverageFieldLength { get; set; }
-            = new Dictionary<string, double>();
+        public Dictionary<string, double> AverageFieldLength { get; set; } = new ();
 
         /// <summary>
         /// The inverted index.
         /// </summary>
-        public InvertedIndex InvertedIndex { get; } = new InvertedIndex();
+        public InvertedIndex InvertedIndex { get; } = new ();
 
         /// <summary>
         /// The vector space of the document fields.
         /// </summary>
-        public IDictionary<string, Vector> FieldVectors { get; set; } = new Dictionary<string, Vector>();
+        public Dictionary<string, Vector> FieldVectors { get; set; } = new ();
 
         /// <summary>
         /// A list of metadata keys that have been allowed for entry in the index.
         /// </summary>
-        public IList<string> MetadataAllowList { get; } = new List<string>();
+        public List<string> MetadataAllowList { get; } = new ();
 
         /// <summary>
         /// The indexing pipeline.

--- a/LunrCore/Document.cs
+++ b/LunrCore/Document.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class Document : Dictionary<string, object>
+    public sealed class Document : Dictionary<string, object>
     {
         public Document() : base() { }
 

--- a/LunrCore/EnglishStemmer.cs
+++ b/LunrCore/EnglishStemmer.cs
@@ -4,11 +4,11 @@ using System.Text.RegularExpressions;
 
 namespace Lunr
 {
-    public class EnglishStemmer : StemmerBase
+    public sealed class EnglishStemmer : StemmerBase
     {
         private static readonly CultureInfo culture = CultureInfo.CreateSpecificCulture("en");
 
-        private static readonly IDictionary<string, string> step2list = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> step2list = new ()
         {
             { "ational", "ate" },
             { "tional", "tion" },
@@ -33,7 +33,7 @@ namespace Lunr
             { "logi", "log" }
         };
 
-        private static readonly IDictionary<string, string> step3list = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> step3list = new ()
         {
             { "icate", "ic" },
             { "ative", "" },

--- a/LunrCore/EnglishStopWordFilter.cs
+++ b/LunrCore/EnglishStopWordFilter.cs
@@ -1,8 +1,8 @@
 ﻿namespace Lunr
 {
-    public class EnglishStopWordFilter : StopWordFilterBase
+    public sealed class EnglishStopWordFilter : StopWordFilterBase
     {
-        private static readonly ISet<string> _stopWords = new Set<string>(new []
+        private static readonly Set<string> _stopWords = new Set<string>(new []
         {
             "a",
             "able",

--- a/LunrCore/Field.cs
+++ b/LunrCore/Field.cs
@@ -37,7 +37,7 @@ namespace Lunr
     /// <summary>
     /// Represents an index field.
     /// </summary>
-    public class Field<T> : Field
+    public sealed class Field<T> : Field
     {
         public Field(string name, double boost = 1, Func<Document, Task<T>>? extractor = null!) : base(name, boost)
             => Extractor = extractor ?? new Func<Document, Task<T>>(doc => Task.FromResult((T)doc[name]));

--- a/LunrCore/FieldMatchMetadata.cs
+++ b/LunrCore/FieldMatchMetadata.cs
@@ -6,7 +6,7 @@ namespace Lunr
     /// The metadata associated with a token match on a field.
     /// The keys are the metadata entry names, the values are lists of values.
     /// </summary>
-    public class FieldMatchMetadata : Dictionary<string, IList<object?>>
+    public sealed class FieldMatchMetadata : Dictionary<string, IList<object?>>
     {
         public FieldMatchMetadata() : base() { }
         public FieldMatchMetadata(int capacity) : base(capacity) { }

--- a/LunrCore/FieldMatches.cs
+++ b/LunrCore/FieldMatches.cs
@@ -6,7 +6,7 @@ namespace Lunr
     /// Represents a set of matches for a field.
     /// The key is a token, and the value is the metadata associated with this token match for this field.
     /// </summary>
-    public class FieldMatches : Dictionary<string, FieldMatchMetadata>
+    public sealed class FieldMatches : Dictionary<string, FieldMatchMetadata>
     {
     }
 }

--- a/LunrCore/FieldTermFrequencies.cs
+++ b/LunrCore/FieldTermFrequencies.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class FieldTermFrequencies : Dictionary<FieldReference, TermFrequencies>
+    public sealed class FieldTermFrequencies : Dictionary<FieldReference, TermFrequencies>
     {
     }
 }

--- a/LunrCore/InvertedIndex.cs
+++ b/LunrCore/InvertedIndex.cs
@@ -10,7 +10,7 @@ namespace Lunr
     /// term -> field -> document -> metadataKey -> metadataValue[]
     /// </summary>
     [JsonConverter(typeof(InvertedIndexJsonConverter))]
-    public class InvertedIndex : Dictionary<string, InvertedIndexEntry>
+    public sealed class InvertedIndex : Dictionary<string, InvertedIndexEntry>
     {
         public InvertedIndex() : base() { }
 

--- a/LunrCore/InvertedIndexEntry.cs
+++ b/LunrCore/InvertedIndexEntry.cs
@@ -10,7 +10,7 @@ namespace Lunr
     /// field -> document -> metadataKey -> metadataValue[]
     /// </summary>
     [JsonConverter(typeof(InvertedIndexEntryJsonConverter))]
-    public class InvertedIndexEntry : Dictionary<string, FieldMatches>
+    public sealed class InvertedIndexEntry : Dictionary<string, FieldMatches>
     {
         public InvertedIndexEntry() : base() { }
         public InvertedIndexEntry(IEnumerable<(string term, FieldMatches occurrences)> entries)

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/bleroy/lunr-core</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/LunrCore/Query.cs
+++ b/LunrCore/Query.cs
@@ -40,7 +40,7 @@ namespace Lunr
         /// <summary>
         /// An list of query clauses.
         /// </summary>
-        public IList<Clause> Clauses { get; } = new List<Clause>();
+        public List<Clause> Clauses { get; } = new();
 
         /// <summary>
         /// A negated query is one in which every clause has a presence of

--- a/LunrCore/QueryLexer.cs
+++ b/LunrCore/QueryLexer.cs
@@ -15,7 +15,7 @@ namespace Lunr
 
         private readonly string _str;
         private readonly int _length;
-        private readonly IList<int> _escapeCharPositions = new List<int>();
+        private readonly List<int> _escapeCharPositions = new();
         private int _pos = 0;
         private int _start = 0;
 
@@ -25,7 +25,7 @@ namespace Lunr
             _length = str.Length;
         }
 
-        public IList<Lexeme> Lexemes { get; } = new List<Lexeme>();
+        public List<Lexeme> Lexemes { get; } = new();
 
         private int Width => _pos - _start;
         private bool HasMore => _pos < _length;

--- a/LunrCore/QueryParserException.cs
+++ b/LunrCore/QueryParserException.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class QueryParserException : Exception
+    public sealed class QueryParserException : Exception
     {
         public QueryParserException(string message, int start, int end) : base(message)
         {

--- a/LunrCore/QueryString.cs
+++ b/LunrCore/QueryString.cs
@@ -41,7 +41,7 @@
     /// <example>Term with a boost of 10: "hello^10"</example>
     /// <example>Term with an edit distance of 2: "hello~2"</example>
     /// <example>Terms with presence modifiers: "-foo +bar baz"</example>
-    public class QueryString
+    public readonly struct QueryString
     {
         /// <summary>
         /// Constructs a query string.

--- a/LunrCore/Serialization/IndexJsonConverter.cs
+++ b/LunrCore/Serialization/IndexJsonConverter.cs
@@ -15,7 +15,7 @@ namespace Lunr.Serialization
         public override Index Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             InvertedIndex? invertedIndex = null;
-            IDictionary<string, Vector>? fieldVectors = null;
+            Dictionary<string, Vector>? fieldVectors = null;
             Pipeline? pipeline = null;
             IEnumerable<string>? fields = null;
 

--- a/LunrCore/Serialization/InvertedIndexJsonConverter.cs
+++ b/LunrCore/Serialization/InvertedIndexJsonConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    internal class InvertedIndexJsonConverter : JsonConverter<InvertedIndex>
+    internal sealed class InvertedIndexJsonConverter : JsonConverter<InvertedIndex>
     {
         public override InvertedIndex Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LunrCore/Serialization/JsonConverterExtensions.cs
+++ b/LunrCore/Serialization/JsonConverterExtensions.cs
@@ -74,7 +74,7 @@ namespace Lunr.Serialization
         /// <param name="reader">The reader.</param>
         /// <param name="options">The JSON serialization options.</param>
         /// <returns>The list read from the reader.</returns>
-        public static IList<T> ReadArray<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+        public static List<T> ReadArray<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             reader.AdvanceTo(JsonTokenType.StartArray);
             var result = new List<T>();
@@ -92,7 +92,7 @@ namespace Lunr.Serialization
         /// <param name="reader">The reader.</param>
         /// <param name="options">The JSON serialization options.</param>
         /// <returns>The list read from the reader.</returns>
-        public static IList<object?> ReadArrayOfObjects(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+        public static List<object?> ReadArrayOfObjects(this ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             reader.AdvanceTo(JsonTokenType.StartArray);
             var result = new List<object?>();
@@ -112,7 +112,7 @@ namespace Lunr.Serialization
         /// <param name="reader">The reader.</param>
         /// <param name="options">The JSON serialization options.</param>
         /// <returns>The dictionary read from the reader.</returns>
-        public static IDictionary<string, TValue> ReadDictionaryFromKeyValueSequence<TValue>(
+        public static Dictionary<string, TValue> ReadDictionaryFromKeyValueSequence<TValue>(
             this ref Utf8JsonReader reader,
             JsonSerializerOptions options)
         {
@@ -137,7 +137,7 @@ namespace Lunr.Serialization
         /// <param name="reader">The reader.</param>
         /// <param name="options">The JSON serialization options.</param>
         /// <returns>The dictionary read from the reader.</returns>
-        public static IDictionary<string, object?> ReadDictionary(
+        public static Dictionary<string, object?> ReadDictionary(
             this ref Utf8JsonReader reader,
             JsonSerializerOptions options)
         {

--- a/LunrCore/Set.cs
+++ b/LunrCore/Set.cs
@@ -51,7 +51,7 @@ namespace Lunr
             return other.Union(this);
         }
 
-        private class EmptySety<TEmpty> : ISet<TEmpty>
+        private sealed class EmptySety<TEmpty> : ISet<TEmpty>
         {
             public bool Contains(TEmpty item) => false;
 
@@ -60,7 +60,7 @@ namespace Lunr
             public ISet<TEmpty> Union(ISet<TEmpty> other) => other;
         }
 
-        private class CompleteSet<TComplete> : ISet<TComplete>
+        private sealed class CompleteSet<TComplete> : ISet<TComplete>
         {
             public bool Contains(TComplete item) => true;
 

--- a/LunrCore/TermFrequencies.cs
+++ b/LunrCore/TermFrequencies.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class TermFrequencies : Dictionary<Token, int>
+    public sealed class TermFrequencies : Dictionary<Token, int>
     {
     }
 }

--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -38,8 +38,9 @@ namespace Lunr
         }
 
         public bool IsFinal { get; set; } = false;
-        public IDictionary<char, TokenSet> Edges { get; }
-            = new Dictionary<char, TokenSet>();
+
+        public Dictionary<char, TokenSet> Edges { get; } = new ();
+
         public int Id { get; }
 
         /// <summary>
@@ -394,10 +395,8 @@ namespace Lunr
         public class Builder
         {
             private string _previousWord = "";
-            private readonly IList<(TokenSet parent, char ch, TokenSet child)> _uncheckedNodes
-                = new List<(TokenSet, char, TokenSet)>();
-            private readonly IDictionary<string, TokenSet> _minimizedNodes
-                = new Dictionary<string, TokenSet>();
+            private readonly List<(TokenSet parent, char ch, TokenSet child)> _uncheckedNodes = new();
+            private readonly Dictionary<string, TokenSet> _minimizedNodes = new();
             private readonly TokenSetIdProvider _idProvider;
 
             public Builder(TokenSetIdProvider? idProvider = null!)

--- a/LunrCore/Vector.cs
+++ b/LunrCore/Vector.cs
@@ -19,7 +19,7 @@ namespace Lunr
     [JsonConverter(typeof(VectorJsonConverter))]
     public class Vector
     {
-        private readonly IList<(int index, double value)> _elements;
+        private readonly List<(int index, double value)> _elements;
         private double _magnitude = 0;
 
         public Vector(params (int index, double value)[] elements)


### PR DESCRIPTION
This PR replaces most of the dictionary and list abstractions with their concrete types and seals the classes to eliminate most virtual calls. It also enables support for C#9.

It requires anyone depending on this library to recompile and limits flexibility in the future. If there are any plans to swap types in the future, these changes should be rejected.

Otherwise, keen for thoughts.