### PR TITLE
Improve code quality

### DIFF
--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -18,9 +18,9 @@ namespace Lunr
     /// </summary>
     public class Builder
     {
-        private readonly IDictionary<string, Field> _fields = new Dictionary<string, Field>();
-        private readonly IDictionary<string, Document> _documents = new Dictionary<string, Document>();
-        private readonly IDictionary<FieldReference, int> _fieldLengths = new Dictionary<FieldReference, int>();
+        private readonly Dictionary<string, Field> _fields = new Dictionary<string, Field>();
+        private readonly Dictionary<string, Document> _documents = new Dictionary<string, Document>();
+        private readonly Dictionary<FieldReference, int> _fieldLengths = new Dictionary<FieldReference, int>();
         private readonly ITokenizer _tokenizer;
         private int _termIndex = 0;
         private double _b = 0.75;
@@ -367,7 +367,7 @@ namespace Lunr
             foreach (FieldReference fieldRef in _fieldLengths.Keys)
             {
                 var fieldVector = new Vector();
-                IDictionary<Token, int> termFrequencies = FieldTermFrequencies[fieldRef];
+                Dictionary<Token, int> termFrequencies = FieldTermFrequencies[fieldRef];
                 double fieldBoost = _fields.TryGetValue(fieldRef.FieldName, out Field field)
                     ? field.Boost : 1;
                 double docBoost = _documents.TryGetValue(fieldRef.DocumentReference, out Document doc)

--- a/LunrCore/Clause.cs
+++ b/LunrCore/Clause.cs
@@ -10,7 +10,7 @@ namespace Lunr
     /// match that term against an `Index`.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class Clause
+    public sealed class Clause
     {
         public static readonly Clause Empty = new Clause("");
 

--- a/LunrCore/Document.cs
+++ b/LunrCore/Document.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class Document : Dictionary<string, object>
+    public sealed class Document : Dictionary<string, object>
     {
         public Document() : base() { }
 

--- a/LunrCore/EnglishStemmer.cs
+++ b/LunrCore/EnglishStemmer.cs
@@ -8,7 +8,7 @@ namespace Lunr
     {
         private static readonly CultureInfo culture = CultureInfo.CreateSpecificCulture("en");
 
-        private static readonly IDictionary<string, string> step2list = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> step2list = new Dictionary<string, string>
         {
             { "ational", "ate" },
             { "tional", "tion" },
@@ -33,7 +33,7 @@ namespace Lunr
             { "logi", "log" }
         };
 
-        private static readonly IDictionary<string, string> step3list = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> step3list = new Dictionary<string, string>
         {
             { "icate", "ic" },
             { "ative", "" },

--- a/LunrCore/EnglishStemmer.cs
+++ b/LunrCore/EnglishStemmer.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Lunr
 {
-    public class EnglishStemmer : StemmerBase
+    public sealed class EnglishStemmer : StemmerBase
     {
         private static readonly CultureInfo culture = CultureInfo.CreateSpecificCulture("en");
 

--- a/LunrCore/EnglishStopWordFilter.cs
+++ b/LunrCore/EnglishStopWordFilter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Lunr
 {
-    public class EnglishStopWordFilter : StopWordFilterBase
+    public sealed class EnglishStopWordFilter : StopWordFilterBase
     {
         private static readonly Set<string> _stopWords = new Set<string>(new []
         {

--- a/LunrCore/EnglishStopWordFilter.cs
+++ b/LunrCore/EnglishStopWordFilter.cs
@@ -2,7 +2,7 @@
 {
     public class EnglishStopWordFilter : StopWordFilterBase
     {
-        private static readonly ISet<string> _stopWords = new Set<string>(new []
+        private static readonly Set<string> _stopWords = new Set<string>(new []
         {
             "a",
             "able",

--- a/LunrCore/Field.cs
+++ b/LunrCore/Field.cs
@@ -37,7 +37,7 @@ namespace Lunr
     /// <summary>
     /// Represents an index field.
     /// </summary>
-    public class Field<T> : Field
+    public sealed class Field<T> : Field
     {
         public Field(string name, double boost = 1, Func<Document, Task<T>>? extractor = null!) : base(name, boost)
             => Extractor = extractor ?? new Func<Document, Task<T>>(doc => Task.FromResult((T)doc[name]));

--- a/LunrCore/FieldMatchMetadata.cs
+++ b/LunrCore/FieldMatchMetadata.cs
@@ -6,7 +6,7 @@ namespace Lunr
     /// The metadata associated with a token match on a field.
     /// The keys are the metadata entry names, the values are lists of values.
     /// </summary>
-    public class FieldMatchMetadata : Dictionary<string, IList<object?>>
+    public sealed class FieldMatchMetadata : Dictionary<string, IList<object?>>
     {
         public FieldMatchMetadata() : base() { }
         public FieldMatchMetadata(int capacity) : base(capacity) { }

--- a/LunrCore/FieldMatches.cs
+++ b/LunrCore/FieldMatches.cs
@@ -6,7 +6,7 @@ namespace Lunr
     /// Represents a set of matches for a field.
     /// The key is a token, and the value is the metadata associated with this token match for this field.
     /// </summary>
-    public class FieldMatches : Dictionary<string, FieldMatchMetadata>
+    public sealed class FieldMatches : Dictionary<string, FieldMatchMetadata>
     {
     }
 }

--- a/LunrCore/FieldReference.cs
+++ b/LunrCore/FieldReference.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class FieldReference
+    public sealed class FieldReference
     {
         public const char Joiner = '/';
 

--- a/LunrCore/FieldTermFrequencies.cs
+++ b/LunrCore/FieldTermFrequencies.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class FieldTermFrequencies : Dictionary<FieldReference, TermFrequencies>
+    public sealed class FieldTermFrequencies : Dictionary<FieldReference, TermFrequencies>
     {
     }
 }

--- a/LunrCore/InvertedIndex.cs
+++ b/LunrCore/InvertedIndex.cs
@@ -10,7 +10,7 @@ namespace Lunr
     /// term -> field -> document -> metadataKey -> metadataValue[]
     /// </summary>
     [JsonConverter(typeof(InvertedIndexJsonConverter))]
-    public class InvertedIndex : Dictionary<string, InvertedIndexEntry>
+    public sealed class InvertedIndex : Dictionary<string, InvertedIndexEntry>
     {
         public InvertedIndex() : base() { }
 

--- a/LunrCore/InvertedIndexEntry.cs
+++ b/LunrCore/InvertedIndexEntry.cs
@@ -10,7 +10,7 @@ namespace Lunr
     /// field -> document -> metadataKey -> metadataValue[]
     /// </summary>
     [JsonConverter(typeof(InvertedIndexEntryJsonConverter))]
-    public class InvertedIndexEntry : Dictionary<string, FieldMatches>
+    public sealed class InvertedIndexEntry : Dictionary<string, FieldMatches>
     {
         public InvertedIndexEntry() : base() { }
         public InvertedIndexEntry(IEnumerable<(string term, FieldMatches occurrences)> entries)

--- a/LunrCore/Lexeme.cs
+++ b/LunrCore/Lexeme.cs
@@ -3,7 +3,7 @@
 namespace Lunr
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class Lexeme
+    public sealed class Lexeme
     {
         public static readonly Lexeme Empty
             = new Lexeme(LexemeType.Empty, "", 0, 0);

--- a/LunrCore/MatchData.cs
+++ b/LunrCore/MatchData.cs
@@ -10,7 +10,7 @@ namespace Lunr
     /// <param name="term">The term this match data is associated with.</param>
     /// <param name="field">The field in which the term was found.</param>
     /// <param name="metadata">The metadata recorded about this term in this field.</param>
-    public class MatchData
+    public sealed class MatchData
     {
         public static readonly MatchData Empty = new MatchData("", "", new FieldMatchMetadata());
 

--- a/LunrCore/MatchData.cs
+++ b/LunrCore/MatchData.cs
@@ -76,7 +76,7 @@ namespace Lunr
                 {
                     Posting.Add(term, new FieldMatches());
                 }
-                IDictionary<string, FieldMatchMetadata> thisTermEntry = Posting[term];
+                Dictionary<string, FieldMatchMetadata> thisTermEntry = Posting[term];
                 foreach (string field in fields)
                 {
                     IEnumerable<string> keys = otherMatchData.Posting[term][field].Keys;

--- a/LunrCore/PipelineFunctionRegistry.cs
+++ b/LunrCore/PipelineFunctionRegistry.cs
@@ -6,7 +6,7 @@ namespace Lunr
     /// <summary>
     /// A registry of named pipeline functions.
     /// </summary>
-    public class PipelineFunctionRegistry : Dictionary<string, Pipeline.Function>
+    public sealed class PipelineFunctionRegistry : Dictionary<string, Pipeline.Function>
     {
         public PipelineFunctionRegistry() : base() { }
 

--- a/LunrCore/QueryParserException.cs
+++ b/LunrCore/QueryParserException.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class QueryParserException : Exception
+    public sealed class QueryParserException : Exception
     {
         public QueryParserException(string message, int start, int end) : base(message)
         {

--- a/LunrCore/QueryString.cs
+++ b/LunrCore/QueryString.cs
@@ -41,7 +41,7 @@
     /// <example>Term with a boost of 10: "hello^10"</example>
     /// <example>Term with an edit distance of 2: "hello~2"</example>
     /// <example>Terms with presence modifiers: "-foo +bar baz"</example>
-    public sealed class QueryString
+    public readonly struct QueryString
     {
         /// <summary>
         /// Constructs a query string.

--- a/LunrCore/QueryString.cs
+++ b/LunrCore/QueryString.cs
@@ -41,7 +41,7 @@
     /// <example>Term with a boost of 10: "hello^10"</example>
     /// <example>Term with an edit distance of 2: "hello~2"</example>
     /// <example>Terms with presence modifiers: "-foo +bar baz"</example>
-    public class QueryString
+    public sealed class QueryString
     {
         /// <summary>
         /// Constructs a query string.

--- a/LunrCore/Serialization/IndexJsonConverter.cs
+++ b/LunrCore/Serialization/IndexJsonConverter.cs
@@ -15,7 +15,7 @@ namespace Lunr.Serialization
         public override Index Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             InvertedIndex? invertedIndex = null;
-            IDictionary<string, Vector>? fieldVectors = null;
+            Dictionary<string, Vector>? fieldVectors = null;
             Pipeline? pipeline = null;
             IEnumerable<string>? fields = null;
 

--- a/LunrCore/Serialization/IndexJsonConverter.cs
+++ b/LunrCore/Serialization/IndexJsonConverter.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    internal class IndexJsonConverter : JsonConverter<Index>
+    internal sealed class IndexJsonConverter : JsonConverter<Index>
     {
         /// <summary>
         /// The lunr.js version that this version of the library is designed to be compatible with.

--- a/LunrCore/Serialization/InvertedIndexEntryJsonConverter.cs
+++ b/LunrCore/Serialization/InvertedIndexEntryJsonConverter.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    internal class InvertedIndexEntryJsonConverter : JsonConverter<InvertedIndexEntry>
+    internal sealed class InvertedIndexEntryJsonConverter : JsonConverter<InvertedIndexEntry>
     {
         public override InvertedIndexEntry Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LunrCore/Serialization/InvertedIndexJsonConverter.cs
+++ b/LunrCore/Serialization/InvertedIndexJsonConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    internal class InvertedIndexJsonConverter : JsonConverter<InvertedIndex>
+    internal sealed class InvertedIndexJsonConverter : JsonConverter<InvertedIndex>
     {
         public override InvertedIndex Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LunrCore/Serialization/JsonConverterExtensions.cs
+++ b/LunrCore/Serialization/JsonConverterExtensions.cs
@@ -8,7 +8,7 @@ namespace Lunr.Serialization
     /// <summary>
     /// A collection of useful helpers to write JSON converters.
     /// </summary>
-    public static class JsonConverterExtensions
+    internal static class JsonConverterExtensions
     {
         private static readonly JsonTokenType[] _ignorableTokenTypes = new JsonTokenType[]
         {
@@ -112,7 +112,7 @@ namespace Lunr.Serialization
         /// <param name="reader">The reader.</param>
         /// <param name="options">The JSON serialization options.</param>
         /// <returns>The dictionary read from the reader.</returns>
-        public static IDictionary<string, TValue> ReadDictionaryFromKeyValueSequence<TValue>(
+        public static Dictionary<string, TValue> ReadDictionaryFromKeyValueSequence<TValue>(
             this ref Utf8JsonReader reader,
             JsonSerializerOptions options)
         {
@@ -137,7 +137,7 @@ namespace Lunr.Serialization
         /// <param name="reader">The reader.</param>
         /// <param name="options">The JSON serialization options.</param>
         /// <returns>The dictionary read from the reader.</returns>
-        public static IDictionary<string, object?> ReadDictionary(
+        public static Dictionary<string, object?> ReadDictionary(
             this ref Utf8JsonReader reader,
             JsonSerializerOptions options)
         {

--- a/LunrCore/Serialization/SliceConverter.cs
+++ b/LunrCore/Serialization/SliceConverter.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    public class SliceConverter : JsonConverter<Slice>
+    public sealed class SliceConverter : JsonConverter<Slice>
     {
         public override Slice Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LunrCore/Serialization/SliceConverter.cs
+++ b/LunrCore/Serialization/SliceConverter.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    public sealed class SliceConverter : JsonConverter<Slice>
+    internal sealed class SliceConverter : JsonConverter<Slice>
     {
         public override Slice Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LunrCore/Serialization/VectorJsonConverter.cs
+++ b/LunrCore/Serialization/VectorJsonConverter.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Lunr.Serialization
 {
-    internal class VectorJsonConverter : JsonConverter<Vector>
+    internal sealed class VectorJsonConverter : JsonConverter<Vector>
     {
         public override Vector Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LunrCore/TermFrequencies.cs
+++ b/LunrCore/TermFrequencies.cs
@@ -2,7 +2,7 @@
 
 namespace Lunr
 {
-    public class TermFrequencies : Dictionary<Token, int>
+    public sealed class TermFrequencies : Dictionary<Token, int>
     {
     }
 }

--- a/LunrCore/TokenMetadata.cs
+++ b/LunrCore/TokenMetadata.cs
@@ -6,7 +6,7 @@ namespace Lunr
     /// <summary>
     /// Represents the metadata associated with a token.
     /// </summary>
-    public class TokenMetadata : Dictionary<string, object?>
+    public sealed class TokenMetadata : Dictionary<string, object?>
     {
         public TokenMetadata() : base() { }
         public TokenMetadata(int capacity) : base(capacity) { }

--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -394,9 +394,9 @@ namespace Lunr
         public class Builder
         {
             private string _previousWord = "";
-            private readonly IList<(TokenSet parent, char ch, TokenSet child)> _uncheckedNodes
+            private readonly List<(TokenSet parent, char ch, TokenSet child)> _uncheckedNodes
                 = new List<(TokenSet, char, TokenSet)>();
-            private readonly IDictionary<string, TokenSet> _minimizedNodes
+            private readonly Dictionary<string, TokenSet> _minimizedNodes
                 = new Dictionary<string, TokenSet>();
             private readonly TokenSetIdProvider _idProvider;
 

--- a/LunrCore/Tokenizer.cs
+++ b/LunrCore/Tokenizer.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 
 namespace Lunr
 {
-    public class Tokenizer : ITokenizer
+    public sealed class Tokenizer : ITokenizer
     {
         /// <summary>
         /// Gets the default separator matching spaces and `-` used by the tokenizer.

--- a/LunrCore/Trimmer.cs
+++ b/LunrCore/Trimmer.cs
@@ -24,7 +24,7 @@ namespace Lunr
         public Pipeline.Function FilterFunction => TrimImplementation;
     }
 
-    public class Trimmer : TrimmerBase
+    public sealed class Trimmer : TrimmerBase
     {
         private static readonly Regex _trimStartExpression = new Regex(@"^\W+");
         private static readonly Regex _trimEndExpression = new Regex(@"\W+$");

--- a/LunrCore/Vector.cs
+++ b/LunrCore/Vector.cs
@@ -19,7 +19,7 @@ namespace Lunr
     [JsonConverter(typeof(VectorJsonConverter))]
     public class Vector
     {
-        private readonly IList<(int index, double value)> _elements;
+        private readonly List<(int index, double value)> _elements;
         private double _magnitude = 0;
 
         public Vector(params (int index, double value)[] elements)


### PR DESCRIPTION
- Makes JsonConverterExtensions internal
- Uses concrete types for private members
- Seals various classes
- Changes QueryString to readonly struct