### PR TITLE
Add SourceLink publishing

### DIFF
--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -18,6 +18,7 @@
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -12,6 +12,7 @@
     <PackageIcon>LunrCore.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/bleroy/lunr-core</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -22,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Follows guidance [here](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink) to enable navigating source in Visual Studio for consumers.