### PR TITLE
Cross target .NET5.0 and use C#9

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403        
+        dotnet-version: 5.0.203        
     - name: Checkout lmdb
       uses: actions/checkout@v2
       with:

--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -387,7 +387,7 @@ namespace Lunr
                         (TermFrequencySaturationFactor *
                             (1 - FieldLengthNormalizationFactor +
                                 FieldLengthNormalizationFactor *
-                                    (_fieldLengths[fieldRef] / AverageFieldLength[field.Name])
+                                    (_fieldLengths[fieldRef] / AverageFieldLength[field!.Name])
                              ) + tf
                         )
                         * fieldBoost

--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -18,9 +18,9 @@ namespace Lunr
     /// </summary>
     public class Builder
     {
-        private readonly Dictionary<string, Field> _fields = new Dictionary<string, Field>();
-        private readonly Dictionary<string, Document> _documents = new Dictionary<string, Document>();
-        private readonly Dictionary<FieldReference, int> _fieldLengths = new Dictionary<FieldReference, int>();
+        private readonly Dictionary<string, Field> _fields = new ();
+        private readonly Dictionary<string, Document> _documents = new ();
+        private readonly Dictionary<FieldReference, int> _fieldLengths = new ();
         private readonly ITokenizer _tokenizer;
         private int _termIndex = 0;
         private double _b = 0.75;
@@ -220,7 +220,7 @@ namespace Lunr
             CultureInfo? culture = null!,
             CancellationToken? cancellationToken = null!)
         {
-            string docRef = doc[ReferenceField].ToString();
+            string docRef = doc[ReferenceField].ToString()!;
 
             _documents[docRef]
                 = new Document(attributes ?? new Dictionary<string, object>())
@@ -368,9 +368,9 @@ namespace Lunr
             {
                 var fieldVector = new Vector();
                 Dictionary<Token, int> termFrequencies = FieldTermFrequencies[fieldRef];
-                double fieldBoost = _fields.TryGetValue(fieldRef.FieldName, out Field field)
+                double fieldBoost = _fields.TryGetValue(fieldRef.FieldName, out Field? field)
                     ? field.Boost : 1;
-                double docBoost = _documents.TryGetValue(fieldRef.DocumentReference, out Document doc)
+                double docBoost = _documents.TryGetValue(fieldRef.DocumentReference, out Document? doc)
                     ? doc.Boost : 1;
 
                 foreach ((Token term, int tf) in termFrequencies)

--- a/LunrCore/Field.cs
+++ b/LunrCore/Field.cs
@@ -12,7 +12,7 @@ namespace Lunr
     {
         protected Field(string name, double boost = 1)
         {
-            if (name == "") throw new InvalidOperationException("Can't create a field with an empty name.");
+            if (name is "") throw new InvalidOperationException("Can't create a field with an empty name.");
             if (name.IndexOf('/') != -1) throw new InvalidOperationException($"Can't create a field with a '/' character in its name \"{name}\".");
 
             Name = name;

--- a/LunrCore/FieldReference.cs
+++ b/LunrCore/FieldReference.cs
@@ -30,10 +30,10 @@ namespace Lunr
         public override string ToString()
             => _stringValue ??= FieldName + Joiner + DocumentReference;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is FieldReference otherRef
-                && otherRef.FieldName == FieldName
-                && otherRef.DocumentReference == DocumentReference;
+                && otherRef.FieldName.Equals(FieldName, StringComparison.Ordinal)
+                && otherRef.DocumentReference.Equals(DocumentReference, StringComparison.Ordinal);
 
         public override int GetHashCode() => (DocumentReference, FieldName).GetHashCode();
     }

--- a/LunrCore/Index.cs
+++ b/LunrCore/Index.cs
@@ -391,7 +391,7 @@ namespace Lunr
                                 var matchingFieldRef = new FieldReference(matchingDocumentRef, field);
                                 FieldMatchMetadata metadata = fieldPosting[matchingDocumentRef];
                                 
-                                if (!matchingFields.TryGetValue(matchingFieldRef, out MatchData fieldMatch))
+                                if (!matchingFields.TryGetValue(matchingFieldRef, out MatchData? fieldMatch))
                                 {
                                     matchingFields.Add(
                                         matchingFieldRef,
@@ -480,7 +480,7 @@ namespace Lunr
                 Vector fieldVector = FieldVectors[fieldRefString];
                 double score = queryVectors[fieldRef.FieldName].Similarity(fieldVector);
 
-                if (matches.TryGetValue(docRef, out Result docMatch))
+                if (matches.TryGetValue(docRef, out Result? docMatch))
                 {
                     docMatch.Score += score;
                     docMatch.MatchData.Combine(matchingFields[fieldRef]);
@@ -537,7 +537,7 @@ namespace Lunr
             StemmerBase? stemmer = null!,
             PipelineFunctionRegistry? registry = null!)
         {
-            Index index = await JsonSerializer.DeserializeAsync<Index>(utf8json);
+            Index index = (await JsonSerializer.DeserializeAsync<Index>(utf8json).ConfigureAwait(false))!;
             return ProcessDeserializedIndex(stemmer, registry, index);
         }
 
@@ -553,7 +553,7 @@ namespace Lunr
             StemmerBase? stemmer = null!,
             PipelineFunctionRegistry? registry = null!)
         {
-            Index index = JsonSerializer.Deserialize<Index>(json);
+            Index index = JsonSerializer.Deserialize<Index>(json)!;
             return ProcessDeserializedIndex(stemmer, registry, index);
         }
 

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <RootNamespace>Lunr</RootNamespace>
-    <Version>2.3.8.5</Version>
+    <Version>2.3.9.0</Version>
     <Authors>Bertrand Le Roy</Authors>
     <Company>Decent Consulting</Company>
     <Description>A .NET Core port of Oliver Nightingale's lunr.js library, a lightweight full-text indexing library that is "a bit like Solr, but much smaller and not as bright." Icon adapted from https://commons.wikimedia.org/wiki/File:Internal_Structure_of_the_Moon.JPG by Iqbal Mahmud under Creative Commons Attribution Share Alike 4.0 International</Description>

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -19,6 +19,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <RootNamespace>Lunr</RootNamespace>
     <Version>2.3.8.5</Version>
     <Authors>Bertrand Le Roy</Authors>
@@ -14,22 +14,25 @@
     <RepositoryUrl>https://github.com/bleroy/lunr-core</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
   
   <ItemGroup>
-    <None Include="Assets/LunrCore.png" Pack="true" PackagePath=""/>
-    <None Include="../LICENSE" Pack="true" PackagePath=""/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="Assets/LunrCore.png" Pack="true" PackagePath="" />
+    <None Include="../LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/LunrCore/Pipeline.cs
+++ b/LunrCore/Pipeline.cs
@@ -184,7 +184,7 @@ namespace Lunr
             if (_process.Any()) throw new InvalidOperationException("This pipeline has already been loaded.");
             foreach (string function in functions)
             {
-                if (RegisteredFunctions.TryGetValue(function, out Function registeredFunction))
+                if (RegisteredFunctions.TryGetValue(function, out Function? registeredFunction))
                 {
                     _process.Add(registeredFunction);
                 }

--- a/LunrCore/Serialization/InvertedIndexEntryJsonConverter.cs
+++ b/LunrCore/Serialization/InvertedIndexEntryJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Lunr.Serialization
             while (reader.AdvanceTo(JsonTokenType.PropertyName, JsonTokenType.EndObject) != JsonTokenType.EndObject)
             {
                 string fieldName = reader.ReadValue<string>(options);
-                if (fieldName == "_index")
+                if (fieldName is "_index")
                 {
                     result.Index = reader.ReadValue<int>(options);
                 }
@@ -40,7 +40,7 @@ namespace Lunr.Serialization
                             while (reader.TokenType != JsonTokenType.EndArray)
                             {
                                 // Special-case known metadata
-                                if (metadataName == "position")
+                                if (metadataName is "position")
                                 {
                                     data.Add(JsonSerializer.Deserialize<Slice>(ref reader, options));
                                 }

--- a/LunrCore/Serialization/JsonConverterExtensions.cs
+++ b/LunrCore/Serialization/JsonConverterExtensions.cs
@@ -35,7 +35,7 @@ namespace Lunr.Serialization
         public static T ReadValue<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             JsonConverter<T> converter = options.GetConverter<T>();
-            T result = converter.Read(ref reader, typeof(T), options);
+            T result = converter.Read(ref reader, typeof(T), options)!;
             reader.ReadOrThrow();
             return result;
         }

--- a/LunrCore/Slice.cs
+++ b/LunrCore/Slice.cs
@@ -36,7 +36,7 @@ namespace Lunr
 
         public void Deconstruct(out int start, out int length) => (start, length) = (Start, Length);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Slice otherSlice && Start == otherSlice.Start && Length == otherSlice.Length;
         }

--- a/LunrCore/Token.cs
+++ b/LunrCore/Token.cs
@@ -69,7 +69,7 @@ namespace Lunr
 
         public static implicit operator string(Token token) => token.String;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj switch
             {
                 null => false,

--- a/LunrCore/Token.cs
+++ b/LunrCore/Token.cs
@@ -9,7 +9,7 @@ namespace Lunr
         /// </summary>
         /// <param name="tokenString">The token string.</param>
         /// <param name="metadata">Metadata associated with this token.</param>
-        public Token(string tokenString, TokenMetadata? metadata = null!)
+        public Token(string tokenString, TokenMetadata? metadata = null)
         {
             String = tokenString ?? "";
             Metadata = metadata ?? new TokenMetadata();

--- a/LunrCore/Token.cs
+++ b/LunrCore/Token.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Lunr
 {
-    public class Token
+    public sealed class Token
     {
         /// <summary>
         /// Creates a new token from a string.

--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -114,7 +114,7 @@ namespace Lunr
                     char ch = frameStr[0];
 
                     TokenSet noEditNode;
-                    if (frameNode.Edges.TryGetValue(ch, out TokenSet existingChNode))
+                    if (frameNode.Edges.TryGetValue(ch, out TokenSet? existingChNode))
                     {
                         noEditNode = existingChNode;
                     }
@@ -139,7 +139,7 @@ namespace Lunr
 
                 // insertion
                 TokenSet insertionNode;
-                if (frameNode.Edges.TryGetValue(Query.Wildcard, out TokenSet wildcardNode))
+                if (frameNode.Edges.TryGetValue(Query.Wildcard, out TokenSet? wildcardNode))
                 {
                     insertionNode = wildcardNode;
                 }
@@ -183,7 +183,7 @@ namespace Lunr
                 if (frameStr.Length >= 1)
                 {
                     TokenSet substitutionNode;
-                    if (frameNode.Edges.TryGetValue(Query.Wildcard, out TokenSet substitutionWildcardNode))
+                    if (frameNode.Edges.TryGetValue(Query.Wildcard, out TokenSet? substitutionWildcardNode))
                     {
                         substitutionNode = substitutionWildcardNode;
                     }
@@ -213,7 +213,7 @@ namespace Lunr
                     char chB = frameStr[1];
                     TokenSet transposeNode;
 
-                    if (frameNode.Edges.TryGetValue(chB, out TokenSet chBNode))
+                    if (frameNode.Edges.TryGetValue(chB, out TokenSet? chBNode))
                     {
                         transposeNode = chBNode;
                     }
@@ -294,7 +294,7 @@ namespace Lunr
         /// <returns>The list of strings in the token set.</returns>
         public IEnumerable<string> ToEnumeration()
         {
-            Stack<(string prefix, TokenSet node)> stack = new Stack<(string, TokenSet)>();
+            Stack<(string prefix, TokenSet node)> stack = new ();
             stack.Push(("", this));
 
             while (stack.Any())
@@ -326,8 +326,7 @@ namespace Lunr
         {
             var output = new TokenSet(_idProvider);
 
-            Stack<(TokenSet qNode, TokenSet output, TokenSet node)> stack
-                = new Stack<(TokenSet, TokenSet, TokenSet)>();
+            Stack<(TokenSet qNode, TokenSet output, TokenSet node)> stack = new ();
             stack.Push((other, output, this));
 
             while (stack.Any())
@@ -342,7 +341,7 @@ namespace Lunr
                         {
                             bool isFinal = node.IsFinal && qNode.IsFinal;
 
-                            if (frameOutput.Edges.TryGetValue(nEdge, out TokenSet next))
+                            if (frameOutput.Edges.TryGetValue(nEdge, out TokenSet? next))
                             {
                                 // an edge already exists for this character
                                 // no need to create a new node, just set the finality
@@ -391,13 +390,11 @@ namespace Lunr
             return str.ToString();
         }
 
-        public class Builder
+        public sealed class Builder
         {
             private string _previousWord = "";
-            private readonly List<(TokenSet parent, char ch, TokenSet child)> _uncheckedNodes
-                = new List<(TokenSet, char, TokenSet)>();
-            private readonly Dictionary<string, TokenSet> _minimizedNodes
-                = new Dictionary<string, TokenSet>();
+            private readonly List<(TokenSet parent, char ch, TokenSet child)> _uncheckedNodes = new ();
+            private readonly Dictionary<string, TokenSet> _minimizedNodes = new ();
             private readonly TokenSetIdProvider _idProvider;
 
             public Builder(TokenSetIdProvider? idProvider = null!)

--- a/LunrCore/Tokenizer.cs
+++ b/LunrCore/Tokenizer.cs
@@ -36,7 +36,7 @@ namespace Lunr
             string str = obj switch
             {
                 DateTime dt => dt.ToEcmaString(),
-                _ => obj.ToString()
+                _ => obj.ToString()!
             };
 
             int tokenCount = 0;
@@ -97,7 +97,7 @@ namespace Lunr
             foreach (object single in enumerable)
             {
                 yield return new Token(
-                    single is null ? "" : single.ToString(),
+                    single is null ? "" : single.ToString()!,
                     metadata is null ? new TokenMetadata() : new TokenMetadata(metadata));
             }
         }

--- a/LunrCore/Util.cs
+++ b/LunrCore/Util.cs
@@ -22,7 +22,7 @@ namespace Lunr
 
             foreach ((string fieldName, FieldMatches value) in posting)
             {
-                if (fieldName == "_index") continue; // Ignore the term index, its not a field
+                if (fieldName is "_index") continue; // Ignore the term index, its not a field
                 documentsWithTerm += value.Count;
             }
 

--- a/LunrCoreLmdb/DelegatedIndex.cs
+++ b/LunrCoreLmdb/DelegatedIndex.cs
@@ -274,7 +274,7 @@ namespace LunrCoreLmdb
                                 var matchingFieldRef = new FieldReference(matchingDocumentRef, field);
                                 FieldMatchMetadata metadata = fieldPosting[matchingDocumentRef];
                                 
-                                if (!matchingFields.TryGetValue(matchingFieldRef, out MatchData fieldMatch))
+                                if (!matchingFields.TryGetValue(matchingFieldRef, out MatchData? fieldMatch))
                                 {
                                     matchingFields.Add(
                                         matchingFieldRef,
@@ -365,7 +365,7 @@ namespace LunrCoreLmdb
                 Vector? fieldVector = _index.GetFieldVectorByKey(fieldRefString);
                 double score = queryVectors[fieldRef.FieldName].Similarity(fieldVector!);
 
-                if (matches.TryGetValue(docRef, out Result docMatch))
+                if (matches.TryGetValue(docRef, out Result? docMatch))
                 {
                     docMatch.Score += score;
                     docMatch.MatchData.Combine(matchingFields[fieldRef]);

--- a/LunrCoreLmdb/LmdbBuilder.cs
+++ b/LunrCoreLmdb/LmdbBuilder.cs
@@ -221,7 +221,7 @@ namespace LunrCoreLmdb
             CultureInfo? culture = null!,
             CancellationToken? cancellationToken = null!)
         {
-            string docRef = doc[ReferenceField].ToString();
+            string docRef = doc[ReferenceField].ToString()!;
 
             _documents[docRef]
                 = new Document(attributes ?? new Dictionary<string, object>())
@@ -376,9 +376,9 @@ namespace LunrCoreLmdb
             {
                 var fieldVector = new Vector();
                 Dictionary<Token, int> termFrequencies = FieldTermFrequencies[fieldRef];
-                double fieldBoost = _fields.TryGetValue(fieldRef.FieldName, out Field field)
+                double fieldBoost = _fields.TryGetValue(fieldRef.FieldName, out Field? field)
                     ? field.Boost : 1;
-                double docBoost = _documents.TryGetValue(fieldRef.DocumentReference, out Document doc)
+                double docBoost = _documents.TryGetValue(fieldRef.DocumentReference, out Document? doc)
                     ? doc.Boost : 1;
 
                 foreach ((Token term, int tf) in termFrequencies)
@@ -395,7 +395,7 @@ namespace LunrCoreLmdb
                         (TermFrequencySaturationFactor *
                             (1 - FieldLengthNormalizationFactor +
                                 FieldLengthNormalizationFactor *
-                                    (_fieldLengths[fieldRef] / AverageFieldLength[field.Name])
+                                    (_fieldLengths[fieldRef] / AverageFieldLength[field!.Name])
                              ) + tf
                         )
                         * fieldBoost

--- a/LunrCoreLmdb/LmdbBuilder.cs
+++ b/LunrCoreLmdb/LmdbBuilder.cs
@@ -19,9 +19,9 @@ namespace LunrCoreLmdb
     /// </summary>
     public class LmdbBuilder
     {
-        private readonly Dictionary<string, Field> _fields = new Dictionary<string, Field>();
-        private readonly Dictionary<string, Document> _documents = new Dictionary<string, Document>();
-        private readonly Dictionary<FieldReference, int> _fieldLengths = new Dictionary<FieldReference, int>();
+        private readonly Dictionary<string, Field> _fields = new ();
+        private readonly Dictionary<string, Document> _documents = new ();
+        private readonly Dictionary<FieldReference, int> _fieldLengths = new ();
         private readonly ITokenizer _tokenizer;
         private int _termIndex = 0;
         private double _b = 0.75;

--- a/LunrCoreLmdb/LunrCoreLmdb.csproj
+++ b/LunrCoreLmdb/LunrCoreLmdb.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCoreLmdb/LunrCoreLmdb.csproj
+++ b/LunrCoreLmdb/LunrCoreLmdb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/LunrCoreLmdbPerf/DelegatedIndexExtensions.cs
+++ b/LunrCoreLmdbPerf/DelegatedIndexExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using Lunr;
 using LunrCoreLmdb;
 

--- a/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
+++ b/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
+++ b/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
+++ b/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCoreLmdbPerf/SearchBenchmarkBase.cs
+++ b/LunrCoreLmdbPerf/SearchBenchmarkBase.cs
@@ -33,8 +33,6 @@ namespace LunrCoreLmdbPerf
             }
         };
 
-       
-
         [Benchmark]
         public async Task SearchSingleTerm()
         {

--- a/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
+++ b/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
+++ b/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
+++ b/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/LunrCorePerf/LunrCorePerf.csproj
+++ b/LunrCorePerf/LunrCorePerf.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCorePerf/LunrCorePerf.csproj
+++ b/LunrCorePerf/LunrCorePerf.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCoreTests/LunrCoreTests.csproj
+++ b/LunrCoreTests/LunrCoreTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/LunrCoreTests/LunrCoreTests.csproj
+++ b/LunrCoreTests/LunrCoreTests.csproj
@@ -1,17 +1,23 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LunrCoreTests/StemmerTests.cs
+++ b/LunrCoreTests/StemmerTests.cs
@@ -15,7 +15,7 @@ namespace LunrCoreTests
         {
             Dictionary<string, string> testData = JsonSerializer
                 .Deserialize<Dictionary<string, string>>(
-                    File.ReadAllText(Path.Combine("fixtures", "stemming_vocab.json")));
+                    File.ReadAllText(Path.Combine("fixtures", "stemming_vocab.json")))!;
 
             foreach((string word, string expected) in testData)
             {


### PR DESCRIPTION
- Cross targets .NET5.0 to eliminate nuget deps (if accepted, we should bump this target to .NET6 in the fall)
- Reacts to nullability changes
- Update xunit and test sdk to latest versions
- Uses target type new()
- Seals Token class
- Updates a few nullability defaults in test / perf projects to reduce warnings
- Eliminate a few culture specific compares
- Update SDK to  5.0.203