### PR TITLE
Fixed potential bug in Index.cs where having +only (or other key word…

### DIFF
--- a/LunrCore/Index.cs
+++ b/LunrCore/Index.cs
@@ -313,7 +313,10 @@ namespace Lunr
                     {
                         foreach (string field in clause.Fields)
                         {
-                            requiredMatches.Add(field, Set<string>.Empty);
+                            if (!requiredMatches.TryGetValue(field, out var value))
+                            {
+                                requiredMatches.Add(field, Set<string>.Empty);
+                            }
                         }
 
                         break;


### PR DESCRIPTION
Fixed potential bug in Index.cs where having +only (or other key words) in the search term caused adding the fields to reuqiredMatches dictionary to throw an exception for duplicate dictionary entry.
