### PR TITLE
Make ExtractValue synchronous

### DIFF
--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -196,7 +196,7 @@ namespace Lunr
         /// <param name="fieldName">The name of a field to index in all documents.</param>
         /// <param name="boost">An optional boost for this field.</param>
         /// <param name="extractor">An optional extraction function for this field's values.</param>
-        public Builder AddField(string fieldName, double boost = 1, Func<Document, Task<string>>? extractor = null)
+        public Builder AddField(string fieldName, double boost = 1, Func<Document, string>? extractor = null)
             => AddField(new Field<string>(fieldName, boost, extractor));
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace Lunr
 
             foreach (Field field in Fields)
             {
-                object? fieldValue = await field.ExtractValue(doc).ConfigureAwait(false);
+                object? fieldValue = field.ExtractValue(doc);
                 if (fieldValue is null) continue;
                 
                 var metadata = new TokenMetadata
@@ -394,7 +394,8 @@ namespace Lunr
                         )
                         * fieldBoost
                         * docBoost;
-                    double scoreWithPrecision = Math.Round(score * 1000) / 1000;
+                    double scoreWithPrecision = Math.Round(score, 3);
+
                     // Converts 1.23456789 to 1.234.
                     // Reducing the precision so that the vectors take up less
                     // space when serialized. Doing it now so that they behave

--- a/LunrCore/Field.cs
+++ b/LunrCore/Field.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Threading.Tasks;
 
 namespace Lunr
 {
@@ -29,7 +28,7 @@ namespace Lunr
         /// </summary>
         public double Boost { get; }
 
-        public abstract Task<object?> ExtractValue(Document doc);
+        public abstract object? ExtractValue(Document doc);
 
         private string DebuggerDisplay => Boost != 1 ? $"{Name} x{Boost}" : Name;
     }
@@ -39,15 +38,16 @@ namespace Lunr
     /// </summary>
     public sealed class Field<T> : Field
     {
-        public Field(string name, double boost = 1, Func<Document, Task<T>>? extractor = null) : base(name, boost)
-            => Extractor = extractor ?? (doc => Task.FromResult((T)doc[name]));
-
+        public Field(string name, double boost = 1, Func<Document, T>? extractor = null) : base(name, boost) =>
+            Extractor = extractor ?? (doc => (T)doc[name]);
+        
         /// <summary>
         /// Function to extract a field from a document.
         /// </summary>
-        public Func<Document, Task<T>> Extractor { get; }
+        public Func<Document, T> Extractor { get; }
 
-        public override async Task<object?> ExtractValue(Document doc)
-            => await Extractor(doc).ConfigureAwait(false);
+        public override object? ExtractValue(Document doc)
+            => Extractor(doc);
+
     }
 }

--- a/LunrCoreLmdb/LmdbBuilder.cs
+++ b/LunrCoreLmdb/LmdbBuilder.cs
@@ -197,7 +197,7 @@ namespace LunrCoreLmdb
         /// <param name="fieldName">The name of a field to index in all documents.</param>
         /// <param name="boost">An optional boost for this field.</param>
         /// <param name="extractor">An optional extraction function for this field's values.</param>
-        public LmdbBuilder AddField(string fieldName, double boost = 1, Func<Document, Task<string>>? extractor = null!)
+        public LmdbBuilder AddField(string fieldName, double boost = 1, Func<Document, string>? extractor = null!)
             => AddField(new Field<string>(fieldName, boost, extractor));
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace LunrCoreLmdb
 
             foreach (Field field in Fields)
             {
-                object? fieldValue = await field.ExtractValue(doc);
+                object? fieldValue = field.ExtractValue(doc);
                 if (fieldValue is null) continue;
                 
                 var metadata = new TokenMetadata

--- a/LunrCoreLmdbTests/LmdbBuilderTests.cs
+++ b/LunrCoreLmdbTests/LmdbBuilderTests.cs
@@ -130,8 +130,8 @@ namespace LunrCoreLmdbTests
             Assert.Empty(index.GetInvertedIndexEntryByKey("bob")!["name"]["id"]);
         }
 
-        private static async Task<string> ExtractName(Document doc)
-            => await Task.FromResult(((IDictionary<string, string>)doc["person"])["name"]);
+        private static string ExtractName(Document doc)
+            => ((IDictionary<string, string>)doc["person"])["name"];
 
         [Fact]
         public void DefiningFieldsToIndex()

--- a/LunrCoreTests/BuilderTests.cs
+++ b/LunrCoreTests/BuilderTests.cs
@@ -111,8 +111,8 @@ namespace LunrCoreTests
             Assert.Empty(builder.InvertedIndex["bob"]["name"]["id"]);
         }
 
-        private static async Task<string> ExtractName(Document doc)
-            => await Task.FromResult(((IDictionary<string, string>)doc["person"])["name"]);
+        private static string ExtractName(Document doc)
+            => ((IDictionary<string, string>)doc["person"])["name"];
 
         [Fact]
         public void DefiningFieldsToIndex()


### PR DESCRIPTION
We're building hundreds of thousands of unique indexes and these Task allocations were showing up a hot spot. Is there a strong case to use a task and state machine here -- or can value extraction be made sync?