### PR TITLE
Fix: Avoid exception witch multiple mandatory fields

### DIFF
--- a/LunrCore/Index.cs
+++ b/LunrCore/Index.cs
@@ -313,7 +313,10 @@ namespace Lunr
                     {
                         foreach (string field in clause.Fields)
                         {
-                            requiredMatches.Add(field, Set<string>.Empty);
+                            if (!requiredMatches.ContainsKey(field))
+                            {
+                                requiredMatches.Add(field, Set<string>.Empty);
+                            }
                         }
 
                         break;

--- a/LunrCoreTests/MultipleMandatoryFieldsTest.cs
+++ b/LunrCoreTests/MultipleMandatoryFieldsTest.cs
@@ -1,0 +1,63 @@
+﻿using Lunr;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LunrCoreTests
+{
+    public class MultipleMandatoryFieldsTest
+    {
+        [Fact]
+        public async Task SearchShouldNotThrowExceptionWhenNoResult()
+        {
+            var index = Lunr.Index.Build(
+                async builder =>
+                {
+                    builder
+                        .AddField("ref")
+                        .AddField("lastname", 3)
+                        .AddField("firstname", 2);
+
+                    builder.ReferenceField = "ref";
+
+                    await builder.Add(new Lunr.Document()
+                    {
+                        { "ref", "0001" },
+                        { "lastname", "Wonderland" },
+                        { "firstname", "Alice" }
+                    });
+
+                    await builder.Add(new Lunr.Document()
+                    {
+                        { "ref", "0002" },
+                        { "lastname", "Sponge" },
+                        { "firstname", "Bob" }
+                    });
+                }
+            ).Result;
+
+            bool caughtException = false;
+
+            try
+            {
+                var results = index.Search("+Alice +abc");
+                int count = 0;
+                await foreach (var result in results)
+                {
+                    count += 1;
+                }
+                Assert.Equal(0, count);
+            }
+            catch (AggregateException)
+            {
+                caughtException = true;
+            }
+
+            Assert.False(caughtException);
+        }
+    }
+}

--- a/LunrCoreTests/MultipleMandatoryFieldsTest.cs
+++ b/LunrCoreTests/MultipleMandatoryFieldsTest.cs
@@ -14,7 +14,7 @@ namespace LunrCoreTests
         [Fact]
         public async Task SearchShouldNotThrowExceptionWhenNoResult()
         {
-            var index = Lunr.Index.Build(
+            var index = await Lunr.Index.Build(
                 async builder =>
                 {
                     builder
@@ -38,26 +38,17 @@ namespace LunrCoreTests
                         { "firstname", "Bob" }
                     });
                 }
-            ).Result;
+            );
 
-            bool caughtException = false;
-
-            try
+            // Lunr throws ArgumentException. This patch fixes the exception.
+            var results = index.Search("+Alice +abc");
+            int count = 0;
+            await foreach (var result in results)
             {
-                var results = index.Search("+Alice +abc");
-                int count = 0;
-                await foreach (var result in results)
-                {
-                    count += 1;
-                }
-                Assert.Equal(0, count);
+                count += 1;
             }
-            catch (AggregateException)
-            {
-                caughtException = true;
-            }
+            Assert.Equal(0, count);
 
-            Assert.False(caughtException);
         }
     }
 }


### PR DESCRIPTION
When a search is performed with multiple mandatory fields, and no result is found, an AggregateException was thrown.

This is a duplicate of PR #39 , with the requested Unit Test.
