### PR TITLE
Cross target net6.0 and eliminate various allocations

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.203        
+        dotnet-version: 6.0.101        
     - name: Checkout lmdb
       uses: actions/checkout@v2
       with:

--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -343,11 +343,8 @@ namespace Lunr
             {
                 string fieldName = fieldRef.FieldName;
 
-                if (!documentsWithField.ContainsKey(fieldName)) documentsWithField.Add(fieldName, 0);
-                documentsWithField[fieldName]++;
-
-                if (!accumulator.ContainsKey(fieldName)) accumulator.Add(fieldName, 0);
-                accumulator[fieldName] += _fieldLengths[fieldRef];
+                documentsWithField.Increment(fieldName);
+                accumulator.Increment(fieldName, _fieldLengths[fieldRef]);
             }
 
             foreach (Field field in Fields)

--- a/LunrCore/Builder.cs
+++ b/LunrCore/Builder.cs
@@ -78,7 +78,7 @@ namespace Lunr
         /// <summary>
         /// The list of fields for this builder.
         /// </summary>
-        public IEnumerable<Field> Fields => _fields.Values;
+        public ICollection<Field> Fields => _fields.Values;
 
         /// <summary>
         /// The set of all tokens in the index.
@@ -267,7 +267,7 @@ namespace Lunr
                     // create an initial posting if one doesn't exist
                     if (!InvertedIndex.ContainsKey(term))
                     {
-                        var posting = new InvertedIndexEntry
+                        var posting = new InvertedIndexEntry(Fields.Count)
                         {
                             Index = _termIndex++
                         };

--- a/LunrCore/Extensions/DictionaryExtensions.cs
+++ b/LunrCore/Extensions/DictionaryExtensions.cs
@@ -8,18 +8,17 @@ internal static class DictionaryExtensions
     public static void Increment(this Dictionary<string, int> dic, string fieldName, int amount = 1)
     {
 #if NET6_0_OR_GREATER
-
         ref int value = ref CollectionsMarshal.GetValueRefOrAddDefault(dic, fieldName, out _);
 
         value += amount;
 #else
-        if (!dic.ContainsKey(fieldName))
+        if (dic.ContainsKey(fieldName))
         {
-            dic.Add(fieldName, amount);
+            dic[fieldName] += amount;
         }
         else 
         {
-            dic[fieldName] += amount;
+            dic.Add(fieldName, amount);
         }
 #endif
 
@@ -28,18 +27,17 @@ internal static class DictionaryExtensions
     public static void Increment(this Dictionary<string, double> dic, string fieldName, double amount = 1)
     {
 #if NET6_0_OR_GREATER
-
         ref double value = ref CollectionsMarshal.GetValueRefOrAddDefault(dic, fieldName, out _);
 
         value += amount;
 #else
-        if (!dic.ContainsKey(fieldName))
+        if (dic.ContainsKey(fieldName))
         {
-            dic.Add(fieldName, amount);
+            dic[fieldName] += amount;
         }
         else 
         {
-            dic[fieldName] += amount;
+            dic.Add(fieldName, amount);
         }
 #endif
 

--- a/LunrCore/Extensions/DictionaryExtensions.cs
+++ b/LunrCore/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Lunr;
+
+internal static class DictionaryExtensions
+{
+    public static void Increment(this Dictionary<string, int> dic, string fieldName, int amount = 1)
+    {
+#if NET6_0_OR_GREATER
+
+        ref int value = ref CollectionsMarshal.GetValueRefOrAddDefault(dic, fieldName, out _);
+
+        value += amount;
+#else
+        if (!dic.ContainsKey(fieldName))
+        {
+            dic.Add(fieldName, amount);
+        }
+        else 
+        {
+            dic[fieldName] += amount;
+        }
+#endif
+
+    }
+
+    public static void Increment(this Dictionary<string, double> dic, string fieldName, double amount = 1)
+    {
+#if NET6_0_OR_GREATER
+
+        ref double value = ref CollectionsMarshal.GetValueRefOrAddDefault(dic, fieldName, out _);
+
+        value += amount;
+#else
+        if (!dic.ContainsKey(fieldName))
+        {
+            dic.Add(fieldName, amount);
+        }
+        else 
+        {
+            dic[fieldName] += amount;
+        }
+#endif
+
+    }
+
+}

--- a/LunrCore/Extensions/StringBuilderExtensions.cs
+++ b/LunrCore/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿#if NETSTANDARD2_0
+
+using System;
+using System.Text;
+
+namespace Lunr;
+
+internal static class StringBuilderExtensions
+{
+    public static void Append(this StringBuilder sb, ReadOnlySpan<char> text)
+    {
+        sb.Append(text.ToString());
+    }
+}
+
+#endif

--- a/LunrCore/InvertedIndex.cs
+++ b/LunrCore/InvertedIndex.cs
@@ -17,5 +17,8 @@ namespace Lunr
 
         public InvertedIndex(IEnumerable<(string term, InvertedIndexEntry entry)> entries)
             : base(entries.ToDictionary(e => e.term, e => e.entry)) { }
+
+        public InvertedIndex(int capacity)
+            : base(capacity) { }
     }
 }

--- a/LunrCore/InvertedIndexEntry.cs
+++ b/LunrCore/InvertedIndexEntry.cs
@@ -15,6 +15,9 @@ namespace Lunr
         public InvertedIndexEntry()
         { }
 
+        public InvertedIndexEntry(int capacity)
+            : base(capacity) { }
+
         public InvertedIndexEntry(IEnumerable<(string term, FieldMatches occurrences)> entries)
             : base(entries.ToDictionary(e => e.term, e => e.occurrences)) { }
 

--- a/LunrCore/LunrCore.csproj
+++ b/LunrCore/LunrCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Lunr</RootNamespace>
     <Version>2.3.10.0</Version>
     <Authors>Bertrand Le Roy</Authors>
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/bleroy/lunr-core</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/LunrCore/MatchData.cs
+++ b/LunrCore/MatchData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Lunr
 {
@@ -95,7 +94,7 @@ namespace Lunr
                         }
                         else
                         {
-                            thisFieldEntry[key] = thisFieldEntry[key].Concat(otherData).ToList();
+                            thisFieldEntry[key] = Concat(thisFieldEntry[key], otherData);
                         }
                     }
                 }
@@ -134,13 +133,35 @@ namespace Lunr
                 FieldMatchMetadata fieldMetadata = termMetadata[field];
                 if (fieldMetadata.ContainsKey(key))
                 {
-                    fieldMetadata[key] = fieldMetadata[key].Concat(metadata[key]).ToList();
+                    fieldMetadata[key] = Concat(fieldMetadata[key], metadata[key]);
                 }
                 else
                 {
                     fieldMetadata[key] = metadata[key];
                 }
             }
+        }
+
+        private static IList<object?> Concat(IList<object?> a, IList<object?> b)
+        {
+            var result = new object?[a.Count + b.Count];
+            int position = 0;
+
+            for (int i = 0; i < a.Count; i++)
+            {
+                result[position] = a[i];
+
+                position++;
+            }
+
+            for (int i = 0; i < b.Count; i++)
+            {
+                result[position] = b[i];
+
+                position++;
+            }
+
+            return result;
         }
     }
 }

--- a/LunrCore/QueryLexer.cs
+++ b/LunrCore/QueryLexer.cs
@@ -154,11 +154,11 @@ namespace Lunr
             foreach (int escapeCharPosition in _escapeCharPositions)
             {
                 int sliceEnd = escapeCharPosition;
-                subSlices.Append(_str.Substring(sliceStart, sliceEnd - sliceStart));
+                subSlices.Append(_str.AsSpan(sliceStart, sliceEnd - sliceStart));
                 sliceStart = sliceEnd + 1;
             }
 
-            subSlices.Append(_str.Substring(sliceStart, _pos - sliceStart));
+            subSlices.Append(_str.AsSpan(sliceStart, _pos - sliceStart));
             _escapeCharPositions.Clear();
 
             return subSlices.ToString();

--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -293,7 +293,7 @@ namespace Lunr
         /// <returns>True if not empty.</returns>
         public bool Any()
         {
-            Stack<(string prefix, TokenSet node)> stack = new Stack<(string, TokenSet)>();
+            var stack = new Stack<(string, TokenSet)>();
             stack.Push(("", this));
 
             while (stack.Any())
@@ -325,7 +325,7 @@ namespace Lunr
         /// <returns>The list of strings in the token set.</returns>
         public IEnumerable<string> ToEnumeration()
         {
-            Stack<(string prefix, TokenSet node)> stack = new ();
+            var stack = new Stack<(string prefix, TokenSet node)>();
             stack.Push(("", this));
 
             while (stack.Any())

--- a/LunrCore/Vector.cs
+++ b/LunrCore/Vector.cs
@@ -29,6 +29,8 @@ namespace Lunr
 
         public Vector() => _elements = new List<(int, double)>();
 
+        public Vector(int capacity) => _elements = new List<(int, double)>(capacity);
+
         /// <summary>
         /// Inserts an element at an index within the vector.
         /// Does not allow duplicates, will throw an error if there is already an entry
@@ -43,7 +45,7 @@ namespace Lunr
         /// Calculates the magnitude of this vector.
         /// </summary>
         public double Magnitude
-            => _magnitude == 0 ? _magnitude = Math.Sqrt(_elements.Sum(el => el.value * el.value)) : _magnitude;
+            => _magnitude == 0 ? _magnitude = Math.Sqrt(_elements.Sum(static el => el.value * el.value)) : _magnitude;
 
         /// <summary>
         /// Calculates the dot product of this vector and another vector.
@@ -111,7 +113,7 @@ namespace Lunr
         public int PositionForIndex(int index)
         {
             // For an empty vector the tuple can be inserted at the beginning
-            if (!_elements.Any())
+            if (_elements.Count is 0)
             {
                 return 0;
             }
@@ -189,6 +191,15 @@ namespace Lunr
         /// </summary>
         /// <returns>The array of elements.</returns>
         public double[] ToArray()
-            => _elements.Select(el => el.value).ToArray();
+        {
+            var result = new double[_elements.Count];
+
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = _elements[i].value;
+            }
+
+            return result;
+        }
     }
 }

--- a/LunrCoreLmdb/LmdbBuilder.cs
+++ b/LunrCoreLmdb/LmdbBuilder.cs
@@ -79,7 +79,7 @@ namespace LunrCoreLmdb
         /// <summary>
         /// The list of fields for this builder.
         /// </summary>
-        public IEnumerable<Field> Fields => _fields.Values;
+        public ICollection<Field> Fields => _fields.Values;
 
         /// <summary>
         /// The set of all tokens in the index.
@@ -266,7 +266,7 @@ namespace LunrCoreLmdb
                     // create an initial posting if one doesn't exist
                     if (!InvertedIndex.ContainsKey(term))
                     {
-                        var posting = new InvertedIndexEntry
+                        var posting = new InvertedIndexEntry(Fields.Count)
                         {
                             Index = _termIndex++
                         };

--- a/LunrCoreLmdb/SerializationExtensions.cs
+++ b/LunrCoreLmdb/SerializationExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+
 using Lunr;
 
 namespace LunrCoreLmdb
@@ -35,15 +35,15 @@ namespace LunrCoreLmdb
 
             var count = context.ReadInt32(ref buffer);
 
-            var values = new List<(int, double)>();
+            var values = new (int, double)[count];
             for (var i = 0; i < count; i++)
             {
                 var index = context.ReadDouble(ref buffer);
                 var value = context.ReadDouble(ref buffer);
-                values.Add(((int) index, value));
+                values[i] = (((int) index, value));
             }
 
-            return new Vector(values.ToArray());
+            return new Vector(values);
         }
 
         #endregion
@@ -73,9 +73,10 @@ namespace LunrCoreLmdb
         
         public static InvertedIndex DeserializeInvertedIndex(this ReadOnlySpan<byte> buffer)
         {
-            var invertedIndex = new InvertedIndex();
             var context = new DeserializeContext(ref buffer);
             var count = context.ReadInt32(ref buffer);
+            var invertedIndex = new InvertedIndex(count);
+
             for (var i = 0; i < count; i++)
             {
                 var key = context.ReadString(ref buffer);

--- a/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
+++ b/LunrCoreLmdbPerf/LunrCoreLmdbPerf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
+++ b/LunrCoreLmdbTests/LunrCoreLmdbTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/LunrCorePerf/LunrCorePerf.csproj
+++ b/LunrCorePerf/LunrCorePerf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LunrCoreTests/LunrCoreTests.csproj
+++ b/LunrCoreTests/LunrCoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR:

- Pre-sizes lists and dictionaries when the size is known (eliminating internal resizes)
- Eliminates substring allocations on .NET5.0+ 
- Eliminates a list allocation on a hot path
- Optimizes CalculateAverageFieldLengths
