### PR TITLE
Documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,4 +27,4 @@ jobs:
           pip install -r docs/requirements.txt
 
       - name: Deploy docs
-        run: mkdocs gh-deploy --force -f mkdocs.yml
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       # Only rebuild website when docs have changed
-      - 'README.md'
       - 'docs/**'
 
 jobs:
@@ -25,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .["docs"]
+          pip install -r docs/requirements.txt
 
       - name: Deploy docs
         run: mkdocs gh-deploy --force -f mkdocs.yml

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,20 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.25
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: docs/mkdocs.yml
+          REQUIREMENTS: docs/requirements.txt

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,7 +2,7 @@ name: Publish docs via GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
       - develop
 
 jobs:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,20 +1,31 @@
 name: Publish docs via GitHub Pages
+
 on:
   push:
     branches:
       - main
-      - develop
+    paths:
+      # Only rebuild website when docs have changed
+      - 'README.md'
+      - 'docs/**'
 
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v2
+      - name: Checkout master
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .["docs"]
+
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.25
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: docs/mkdocs.yml
-          REQUIREMENTS: docs/requirements.txt
+        run: mkdocs gh-deploy --force -f mkdocs.yml

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,94 @@ A port of [lunr.js](https://lunrjs.com/guides/getting_started.html) to .NET Core
 Lunr is a bit like Solr, but much smaller and not as bright.
 
 ![.NET Core](https://github.com/bleroy/lunr-core/workflows/.NET%20Core/badge.svg)
+
+## TODO / up for grabs
+
+* Multilingual support (lunr has optional support that remains to be ported)
+* Documentation (adapted from [lunr docs](https://lunrjs.com/guides/getting_started.html))
+
+## Example
+
+A very simple search index can be created using the following:
+
+```csharp
+var index = await Index.Build(async builder =>
+{
+    builder
+        .AddField("title")
+        .AddField("body");
+
+    await builder.Add(new Document
+    {
+        { "title", "Twelfth-Night" },
+        { "body", "If music be the food of love, play on: Give me excess of it…" },
+        { "author", "William Shakespeare" },
+        { "id", "1" },
+    });
+});
+```
+
+Then searching is as simple as:
+
+```csharp
+await foreach (Result result in index.Search("love"))
+{
+    // do something with that result
+}
+```
+
+This returns a list of matching documents with a [score](https://lunrjs.com/guides/searching.html#scoring) of how closely they match, the search query as well as any associated metadata about the match:
+
+```csharp
+new List<Result>
+{
+    new Result(
+        documentReference: "1",
+        score: 0.3535533905932737,
+        matchData: new MatchData(
+            term: "love",
+            field: "body"
+        )
+    )
+}
+```
+
+<!--[API documentation](https://lunrjs.com/docs/index.html) is available, as well as a [full working example](https://olivernn.github.io/moonwalkers/).-->
+
+## Description
+
+Lunr-core is a small, full-text search library for use in small applications.
+It indexes documents and provides a simple search interface for retrieving documents that best match text queries.
+It is 100% compatible with [lunr.js](https://lunrjs.com/guides/getting_started.html), meaning that an index file prepared on the server with lunr-core can be used on the client using lunr.js.
+
+## Why
+
+Lunr-core is suitable for small applications that require a simple search engine but without the overhead of a full-scale search engine such as Lucene.
+Its compatibility with lunr.js also opens up some interesting client-side search scenarios.
+
+<!--
+## Installation
+
+Simply include the lunr-core package in your application.
+Lunr-core supports all .NET Standard 2.0 platforms, including .NET Core and .NET Framework 4.6.
+-->
+
+## Features
+
+* Soon: Full text search support for 14 languages
+* Boost terms at query time or boost entire documents at index time
+* Scope searches to specific fields
+* Fuzzy term matching with wildcards or edit distance
+* No runtime dependencies beyond SDK, BCL AsyncInterfaces and System.Text.Json
+
+<!--
+## Contributing
+
+See the [`CONTRIBUTING.md` file](CONTRIBUTING.md).
+-->
+
+## Credits
+
+* Original code by [Oliver Nightingale](https://github.com/olivernn) and contributors, ported to .NET Core by [Bertrand Le Roy](https://github.com/bleroy).
+* Icon adapted from https://commons.wikimedia.org/wiki/File:Internal_Structure_of_the_Moon.JPG by Iqbal Mahmud under Creative Commons Attribution Share Alike 4.0 International.
+* Perf tests use a [word list by Sindre Sorhus](https://github.com/sindresorhus/word-list).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# lunr-core
+A port of [lunr.js](https://lunrjs.com/guides/getting_started.html) to .NET Core.
+Lunr is a bit like Solr, but much smaller and not as bright.
+
+![.NET Core](https://github.com/bleroy/lunr-core/workflows/.NET%20Core/badge.svg)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,3 @@
+# Getting started with lunr-core
+
+In this article, we are going to see ...

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,3 @@ mkdocs-git-revision-date-localized-plugin>=1.2.0
 pymdown-extensions>=10.1.0
 mkdocs-exclude>=1.0.2
 mdx_truly_sane_lists>=1.2
-nltk==3.4.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-git-revision-date-localized-plugin>=1.2.0
 pymdown-extensions>=10.1.0
 mkdocs-exclude>=1.0.2
 mdx_truly_sane_lists>=1.2
+nltk==3.4.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+mkdocs>=1.5.1
+mkdocs-material>=9.1.21
+mkdocs-git-authors-plugin>=0.7.2
+mkdocs-git-revision-date-localized-plugin>=1.2.0
+pymdown-extensions>=10.1.0
+mkdocs-exclude>=1.0.2
+mdx_truly_sane_lists>=1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: lunr-core
+theme:
+  name: material
+  
+extra:
+  social:
+    - icon: fontawesome/brands/github-alt
+      link: https://github.com/bleroy/lunr-core
+
+# Repository
+repo_name: bleroy/lunr-core
+repo_url: https://github.com/bleroy/lunr-core
+edit_uri: edit/main/
+
+# Extensions
+markdown_extensions:
+  - markdown.extensions.admonition
+  - markdown.extensions.codehilite
+  - markdown.extensions.def_list
+  - markdown.extensions.footnotes
+  - markdown.extensions.meta
+  - pymdownx.b64
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji
+  - pymdownx.magiclink
+  - pymdownx.smartsymbols
+  - pymdownx.snippets:
+      check_paths: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: false
+  - pymdownx.tasklist
+  - pymdownx.tilde
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - git-authors
+  - git-revision-date-localized
+
+# Page tree
+nav:
+  - About: README.md
+  - Getting started:
+      - Introduction: getting-started/README.md


### PR DESCRIPTION
Use MkDocs and Material theme.

Github workflow pushes to `gh-pages` when a .md file is changed in the docs folder.

I only added a `docs/Readme.md` and a `docs/getting-started/Readme.md`.

![image](https://github.com/bleroy/lunr-core/assets/703248/963f4358-13c5-41f2-a64a-892961e5dd55)

Search is included but it does not use lunr, sorry ;-).

Can be tested locally:
- Run `pip3 install -r docs/requirements.txt` to install dependencies.
- Run `mkdocs serve` to start the site.

Should be available at https://bleroy.github.io/lunr-core/

Ex: https://github.com/agriffard/lunr-core/tree/gh-pages
