### PR TITLE
Trimmer optimization

### DIFF
--- a/LunrCore/Trimmer.cs
+++ b/LunrCore/Trimmer.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,10 +25,28 @@ namespace Lunr
 
     public sealed class Trimmer : TrimmerBase
     {
-        private static readonly Regex _trimStartExpression = new Regex(@"^\W+");
-        private static readonly Regex _trimEndExpression = new Regex(@"\W+$");
-
         public override string Trim(string s)
-            => _trimEndExpression.Replace(_trimStartExpression.Replace(s, ""), "");
+        {
+            int start = 0;
+
+            while (start < s.Length && !char.IsLetterOrDigit(s[start]) && s[start] != '_')
+            {
+                start++;
+            }
+
+            int end = s.Length - 1;
+
+            while (end >= start && !char.IsLetterOrDigit(s[end]) && s[end] != '_')
+            {
+                end--;
+            }
+
+            if (start == 0 && end == s.Length - 1)
+            {
+                return s;
+            }
+
+            return s.Substring(start, end - start + 1);
+        }
     }
 }

--- a/LunrCorePerf/TrimmerBenchmark.cs
+++ b/LunrCorePerf/TrimmerBenchmark.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using Lunr;
+
+namespace LunrCorePerf
+{
+    [MemoryDiagnoser]
+    public class TrimmerBenchmark
+    {
+        private static readonly string[] TestInputs = new[]
+        {
+            "hello",
+            "hello.",
+            "it's",
+            "james'",
+            "stop!'",
+            "first,'",
+            "[tag]'",
+            "__Proto__'"
+        };
+
+        private Trimmer _trimmer = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _trimmer = new Trimmer();
+        }
+
+        [Benchmark]
+        public void TrimAll()
+        {
+            foreach (string input in TestInputs)
+            {
+                _trimmer.Trim(input);
+            }
+        }
+    }
+}

--- a/LunrCoreTests/TrimmerTests.cs
+++ b/LunrCoreTests/TrimmerTests.cs
@@ -13,6 +13,7 @@ namespace LunrCoreTests
         [InlineData("stop!'", "stop")] // exclamation mark
         [InlineData("first,'", "first")] // comma
         [InlineData("[tag]'", "tag")] // brackets
+        [InlineData("__Proto__'", "__Proto__")] // underscore
         public void CheckTrim(string str, string expected)
         {
             Assert.Equal(expected, new Trimmer().Trim(str));


### PR DESCRIPTION
Current trimmer implementation use Regex which is slow.
Replace it with native string manipulation.
This is about 100x faster and also this don't reallocate a string if not needed, so less allocation on average.

Before :
|  Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| TrimAll | 1.007 us | 0.0057 us | 0.0054 us | 0.0114 |     - |     - |     192 B |

After :
|  Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| TrimAll | 65.02 ns | 0.437 ns | 0.388 ns | 0.0101 |     - |     - |     160 B |