### PR TITLE
Fuzzy Search optimization

### DIFF
--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -101,15 +101,24 @@ namespace Lunr
             idProvider ??= TokenSetIdProvider.Instance;
             var root = new TokenSet(idProvider);
 
+            var seen = new HashSet<(int nodeId, string frameStr, int editsRemaining)>();
+
             var stack = new Stack<(TokenSet node, int editsRemaining, string str)>();
             stack.Push((
                 node: root,
                 editsRemaining: editDistance,
                 str));
 
-            while (stack.Any())
+            while (stack.Count > 0)
             {
                 (TokenSet frameNode, int frameEditsRemaining, string frameStr) = stack.Pop();
+
+                // skip if already processed
+                var stateKey = (frameNode.Id, frameStr, frameEditsRemaining);
+                if (!seen.Add(stateKey))
+                {
+                    continue;
+                }
 
                 // no edit
                 if (frameStr.Length > 0)

--- a/LunrCore/TokenSet.cs
+++ b/LunrCore/TokenSet.cs
@@ -109,7 +109,7 @@ namespace Lunr
                 editsRemaining: editDistance,
                 str));
 
-            while (stack.Count > 0)
+            while (stack.Any())
             {
                 (TokenSet frameNode, int frameEditsRemaining, string frameStr) = stack.Pop();
 


### PR DESCRIPTION
A lot of nodes are processed multiple times unnecessary.
Add an hashset to track them and reduce instructions count.